### PR TITLE
[DEVX-2511] Pact Improvements

### DIFF
--- a/pact_broker/Gemfile
+++ b/pact_broker/Gemfile
@@ -6,7 +6,9 @@ gem "puma", "~> 5.6"
 gem "mysql2", "~>0.3"
 gem "sqlite3", "~>1.3"
 gem "rake", "~> 13.0"
+gem 'puma-metrics'
 
 # Need to manually add Webrick because we deleted it from the underlying Docker image
 # because of a vulnerability, and Webmachine requires it in the adapters.rb file.
 gem "webrick", "~> 1.6"
+

--- a/pact_broker/Gemfile.lock
+++ b/pact_broker/Gemfile.lock
@@ -110,8 +110,12 @@ GEM
     padrino-support (0.15.1)
     parslet (2.0.0)
     pg (1.4.1)
+    prometheus-client (4.2.1)
     puma (5.6.4)
       nio4r (~> 2.0)
+    puma-metrics (1.2.5)
+      prometheus-client (>= 0.10)
+      puma (>= 5.0)
     racc (1.6.0)
     rack (2.2.4)
     rack-protection (2.2.0)
@@ -168,6 +172,7 @@ DEPENDENCIES
   pact_broker
   pg (~> 1.0)
   puma (~> 5.6)
+  puma-metrics
   rake (~> 13.0)
   sqlite3 (~> 1.3)
   webrick (~> 1.6)

--- a/pact_broker/config/puma.rb
+++ b/pact_broker/config/puma.rb
@@ -1,6 +1,11 @@
 require_relative "../docker_configuration"
 
+plugin 'metrics'
+puma_metrics_port = ENV['PACT_BROKER_PUMA_METRICS_PORT'] || (PactBroker.docker_configuration.port.to_i + 1).to_s
+
 port PactBroker.docker_configuration.port
+
+metrics_url "tcp://0.0.0.0:#{puma_metrics_port}"
 
 if PactBroker.docker_configuration.puma_persistent_timeout
   persistent_timeout PactBroker.docker_configuration.puma_persistent_timeout

--- a/pact_broker/entrypoint.sh
+++ b/pact_broker/entrypoint.sh
@@ -6,4 +6,4 @@ if [ "${PACT_BROKER_DATABASE_CLEAN_ENABLED}" = "true" ]; then
   /usr/local/bin/supercronic -quiet -passthrough-logs /pact_broker/crontab &
 fi
 
-bundle exec puma
+exec bundle exec puma


### PR DESCRIPTION
### Description

* Run puma with PID 1
* Add puma-metrics

### How To Test

* Build the image with `docker buildx build --platform='linux/amd64' -t "us-central1-docker.pkg.dev/toptal-hub/containers/pact-broker-docker:$(git rev-parse HEAD)" `.
* Change the docker-compose.yml's pact-broker image to "us-central1-docker.pkg.dev/toptal-hub/containers/pact-broker-docker:{{value from build command}}" 
* Start pact-broker with `docker compose up`
* Access the container with `docker-compose exec pact-broker sh`
* Run `ps aux`
* Puma should be running with `PID 1`
![Seleção_633](https://github.com/toptal/pact_broker/assets/15175861/ade5e0a9-f0f7-467b-84b5-e8fe9904f6f2)

* Run `netstat -tulpn`
* Puma should be using ports 9393 (pact broker) and 9394 (puma metrics)
![Seleção_634](https://github.com/toptal/pact_broker/assets/15175861/e6c87b6e-7e10-49eb-8273-695e284239b2)

